### PR TITLE
Update operators.ts

### DIFF
--- a/src/operators.ts
+++ b/src/operators.ts
@@ -6,7 +6,7 @@ import type { NodeRef, Realm } from './realm'
  * @typeParam Out - The type of values that the resulting node will emit.
  * @category Operators
  */
-export type Operator<In, Out> = (source: NodeRef<In>, realm: Realm) => NodeRef<Out>
+export type Operator<In, Out> = (source: NodeRef<In>) => NodeRef<Out>
 
 /**
  * Shorter alias for {@link Operator}, to avoid extra long type signatures.


### PR DESCRIPTION
hello, there are some unused  type code.

realm: Realm is not used in the following code
```typescript
export type Operator<In, Out> = (source: NodeRef<In>, realm: Realm) => NodeRef<Out>;
```
So i remove it.